### PR TITLE
deal with the unfortunate fact that family names contain a lower-case ß

### DIFF
--- a/scrapers/mep.py
+++ b/scrapers/mep.py
@@ -206,7 +206,7 @@ def mangleName(name, id):
     tmp=name.split(' ')
     title=None
     for i,token in enumerate(tmp):
-        if ((token.isupper() and not isabbr(token)) or
+        if ((token.replace("ß", "ẞ").isupper() and not isabbr(token)) or
             token in ['de', 'van', 'von', 'del'] or
             (token == 'in' and tmp[i+1]=="'t" ) or
             (token[:2]=='Mc' and token[2:].isupper())):


### PR DESCRIPTION
This seems a necessary fix to recognise family names containing an ß (German sharp s), which could be capitalised as SS – some people use SZ, or since 2008 [Unicode] or 2017 [official German rules] there is ẞ – but the EP seems to think it best to use a lower-case ß all the same. False positives would arise if there were German first names consisting of just an initial (hence upper-case) letter plus an ß. But that does not seem be the case (says a native German).