### PR TITLE
deobfus_mail: fix indiscriminate truncation

### DIFF
--- a/scrapers/mep.py
+++ b/scrapers/mep.py
@@ -17,7 +17,8 @@
 
 # (C) 2019 by Stefan Marsiske, <parltrack@ctrlc.hu>
 
-import re,sys
+import sys
+import re
 import notification_model as notif
 from utils.utils import fetch, fetch_raw, unws, jdump, getpdf, textdiff
 from utils.process import process
@@ -154,8 +155,8 @@ def scrape(id, **kwargs):
     del mep
 
 def deobfus_mail(txt):
-    x = txt.replace('[at]','@').replace('[dot]','.')
-    return ''.join(x[len('mailto:'):][::-1])
+    x = re.sub(r'^mailto:', '', txt).replace('[at]', '@').replace('[dot]', '.')
+    return ''.join(x[::-1])
 
 def parse_addr(root):
     # addresses


### PR DESCRIPTION
In all email addresses in the current dumps, the last 7 characters are missing. This is because the deobfus_mail function assumes that the href attribute to de-obfuscate always starts with “mailto:”. It left-truncates the obfuscated string by the number of characters in that string.  As it happens, the obfuscated hrefs on the website do not start with “mailto:”, so the characters that are truncated are part of the actual email address. As the de-obfuscation includes reversing the string, the result is effectively right-truncated. Addresses ending in “@europarl.europa.eu” get truncated to “@europarl.eu”, which is deceptively similar. It required the experience of a staff member of European Digital Rights (EDRi) to spot this error. Thanks, J :-) Other addresses on the website end with “@gmail.com” which is shortened to “@gm”.

In the actual website, the Javascript that performs the de-obfuscation is a jQuery plugin (dcSpamless, no longer online, [here](https://web.archive.org/web/20191203133629/http://www.designchemical.com/lab/jquery-spamless-plugin-stop-email-spam/getting-started/) is an archived copy). The [code](https://web.archive.org/web/20150913014207/http://www.designchemical.com/lab/jquery-plugins/jquery-spamless/js/jquery.dcspamless.1.0.js) includes ```replace('mailto:', '')```, so “mailto:” is removed if it does occur but otherwise the string is not shortened. Sadly, “mailto:” gets removed regardless of where it occurs in the string. My Python adaptation uses re.sub to only remove ”mailto:” from the start of the string. Maybe it would be better practice to strictly reproduce the buggy behaviour of the JavaScript code. In practice, I expect that no string will occur that will expose this bug. Maybe my strategy is more future-proof since the JavaScript might get replaced by something more recent that does not include that bug.